### PR TITLE
feat: Provide fee collector in constructor

### DIFF
--- a/contracts/ens/DCLControllerV2.sol
+++ b/contracts/ens/DCLControllerV2.sol
@@ -18,6 +18,8 @@ contract DCLControllerV2 is Ownable {
     IERC20Token public acceptedToken;
     // DCL Registrar
     IDCLRegistrar public registrar;
+    // Fee Collector
+    address public feeCollector;
 
     // Price of each name
     uint256 public maxGasPrice = 20000000000; // 20 gwei
@@ -32,8 +34,9 @@ contract DCLControllerV2 is Ownable {
 	 * @dev Constructor of the contract
      * @param _acceptedToken - address of the accepted token
      * @param _registrar - address of the DCL registrar contract
+     * @param _feeCollector - address of the fee collector
 	 */
-    constructor(IERC20Token _acceptedToken, IDCLRegistrar _registrar) public {
+    constructor(IERC20Token _acceptedToken, IDCLRegistrar _registrar, address _feeCollector) public {
         require(address(_acceptedToken).isContract(), "Accepted token should be a contract");
         require(address(_registrar).isContract(), "Registrar should be a contract");
 
@@ -41,6 +44,8 @@ contract DCLControllerV2 is Ownable {
         acceptedToken = _acceptedToken;
         // DCL registrar
         registrar = _registrar;
+        // Fee Collector
+        feeCollector = _feeCollector;
     }
 
     /**

--- a/contracts/mocks/FakeDCLControllerV2.sol
+++ b/contracts/mocks/FakeDCLControllerV2.sol
@@ -24,7 +24,8 @@ contract FakeDCLControllerV2 is DCLControllerV2 {
 
     constructor(
         IERC20Token _acceptedToken,
-        IDCLRegistrar _registrar
-    ) public DCLControllerV2(_acceptedToken, _registrar) {}
+        IDCLRegistrar _registrar,
+        address _feeCollector
+    ) public DCLControllerV2(_acceptedToken, _registrar, _feeCollector) {}
 
 }

--- a/test/SubdomainWithDCLControllerV2.spec.js
+++ b/test/SubdomainWithDCLControllerV2.spec.js
@@ -1965,7 +1965,7 @@ describe('DCL Names V2 with DCLControllerV2', function () {
         expect(maxGasPrice).to.eq.BN(MAX_GAS_PRICE)
 
         const collector = await dclControllerContract.feeCollector()
-        expect(collector).to.eq.BN(feeCollector)
+        expect(collector).to.be.equal(feeCollector)
       })
 
       it('reverts if acceptedToken is not a contract', async function () {

--- a/test/SubdomainWithDCLControllerV2.spec.js
+++ b/test/SubdomainWithDCLControllerV2.spec.js
@@ -75,6 +75,7 @@ describe('DCL Names V2 with DCLControllerV2', function () {
   let deployer
   let user
   let userController
+  let feeCollector
   let hacker
   let anotherUser
   let fromUserController
@@ -99,6 +100,7 @@ describe('DCL Names V2 with DCLControllerV2', function () {
     anotherUser = accounts[ADDRESS_INDEXES.anotherUser]
     hacker = accounts[ADDRESS_INDEXES.hacker]
     userController = accounts[Object.keys(ADDRESS_INDEXES).length]
+    feeCollector = accounts[Object.keys(ADDRESS_INDEXES).length + 1]
     fromUser = { from: user }
     fromAnotherUser = { from: anotherUser }
     fromUserController = { from: userController }
@@ -176,6 +178,7 @@ describe('DCL Names V2 with DCLControllerV2', function () {
     dclControllerContract = await DCLControllerV2.new(
       manaContract.address,
       dclRegistrarContract.address,
+      feeCollector,
       creationParams
     )
 
@@ -1941,10 +1944,11 @@ describe('DCL Names V2 with DCLControllerV2', function () {
     })
 
     describe('Constructor', function () {
-      it('should be depoyed with valid arguments', async function () {
+      it('should be deployed with valid arguments', async function () {
         const contract = await DCLControllerV2.new(
           manaContract.address,
           dclRegistrarContract.address,
+          feeCollector,
           creationParams
         )
 
@@ -1959,18 +1963,31 @@ describe('DCL Names V2 with DCLControllerV2', function () {
 
         const maxGasPrice = await dclControllerContract.maxGasPrice()
         expect(maxGasPrice).to.eq.BN(MAX_GAS_PRICE)
+
+        const collector = await dclControllerContract.feeCollector()
+        expect(collector).to.eq.BN(feeCollector)
       })
 
       it('reverts if acceptedToken is not a contract', async function () {
         await assertRevert(
-          DCLControllerV2.new(user, dclRegistrarContract.address, creationParams),
+          DCLControllerV2.new(
+            user,
+            dclRegistrarContract.address,
+            feeCollector,
+            creationParams
+          ),
           'Accepted token should be a contract'
         )
       })
 
       it('reverts if registrar is not a contract', async function () {
         await assertRevert(
-          DCLControllerV2.new(manaContract.address, user, creationParams),
+          DCLControllerV2.new(
+            manaContract.address,
+            user,
+            feeCollector,
+            creationParams
+          ),
           'Registrar should be a contract'
         )
       })


### PR DESCRIPTION
Closes #26 

Provide a fee collector via the constructor and store it in the contract.

This unblocks https://github.com/decentraland/avatars-contract/issues/27 were a function to update the fee collector by the owner will be added.