### PR TITLE
feat: Send fee to fee collector

### DIFF
--- a/contracts/ens/DCLControllerV2.sol
+++ b/contracts/ens/DCLControllerV2.sol
@@ -69,7 +69,7 @@ contract DCLControllerV2 is Ownable {
 
         // Register the name
         registrar.register(_name, _beneficiary);
-        // Transfer the fee to the fee collector
+        // Transfer PRICE to the fee collector
         acceptedToken.transferFrom(msg.sender, feeCollector, PRICE);
         // Log
         emit NameBought(msg.sender, _beneficiary, PRICE, _name);

--- a/contracts/ens/DCLControllerV2.sol
+++ b/contracts/ens/DCLControllerV2.sol
@@ -30,6 +30,9 @@ contract DCLControllerV2 is Ownable {
     // Emitted when the max gas price is changed
     event MaxGasPriceChanged(uint256 indexed _oldMaxGasPrice, uint256 indexed _newMaxGasPrice);
 
+    // Emitted when the fee collector is changed
+    event FeeCollectorChanged(address indexed _oldFeeCollector, address indexed _newFeeCollector);
+
     /**
 	 * @dev Constructor of the contract
      * @param _acceptedToken - address of the accepted token
@@ -44,8 +47,8 @@ contract DCLControllerV2 is Ownable {
         acceptedToken = _acceptedToken;
         // DCL registrar
         registrar = _registrar;
-        // Fee Collector
-        feeCollector = _feeCollector;
+
+        _setFeeCollector(_feeCollector);
     }
 
     /**
@@ -91,6 +94,15 @@ contract DCLControllerV2 is Ownable {
     }
 
     /**
+     * @notice Set the fee collector
+     * @dev Only the owner can change the fee collector
+     * @param _feeCollector - the address of the new collector
+     */
+    function setFeeCollector(address _feeCollector) external onlyOwner {
+        _setFeeCollector(_feeCollector);
+    }
+
+    /**
      * @dev Validate if a user has balance and the contract has enough allowance
      * to use user's accepted token on his belhalf
      * @param _user - address of the user
@@ -128,6 +140,12 @@ contract DCLControllerV2 is Ownable {
 
     function _isNumber(bytes1 _char) internal pure returns (bool) {
         return (_char >= 0x30 && _char <= 0x39);
+    }
+
+    function _setFeeCollector(address _feeCollector) internal {
+        emit FeeCollectorChanged(feeCollector, _feeCollector);
+
+        feeCollector = _feeCollector;
     }
 
 }

--- a/contracts/ens/DCLControllerV2.sol
+++ b/contracts/ens/DCLControllerV2.sol
@@ -18,6 +18,8 @@ contract DCLControllerV2 is Ownable {
     IERC20Token public acceptedToken;
     // DCL Registrar
     IDCLRegistrar public registrar;
+    // Fee Collector
+    address public feeCollector;
 
     // Price of each name
     uint256 public maxGasPrice = 20000000000; // 20 gwei
@@ -32,8 +34,9 @@ contract DCLControllerV2 is Ownable {
 	 * @dev Constructor of the contract
      * @param _acceptedToken - address of the accepted token
      * @param _registrar - address of the DCL registrar contract
+     * @param _feeCollector - address of the fee collector
 	 */
-    constructor(IERC20Token _acceptedToken, IDCLRegistrar _registrar) public {
+    constructor(IERC20Token _acceptedToken, IDCLRegistrar _registrar, address _feeCollector) public {
         require(address(_acceptedToken).isContract(), "Accepted token should be a contract");
         require(address(_registrar).isContract(), "Registrar should be a contract");
 
@@ -41,6 +44,8 @@ contract DCLControllerV2 is Ownable {
         acceptedToken = _acceptedToken;
         // DCL registrar
         registrar = _registrar;
+        // Fee Collector
+        feeCollector = _feeCollector;
     }
 
     /**

--- a/contracts/ens/DCLControllerV2.sol
+++ b/contracts/ens/DCLControllerV2.sol
@@ -69,10 +69,8 @@ contract DCLControllerV2 is Ownable {
 
         // Register the name
         registrar.register(_name, _beneficiary);
-        // Debit `price` from sender
-        acceptedToken.transferFrom(msg.sender, address(this), PRICE);
-        // Burn it
-        acceptedToken.burn(PRICE);
+        // Transfer the fee to the fee collector
+        acceptedToken.transferFrom(msg.sender, feeCollector, PRICE);
         // Log
         emit NameBought(msg.sender, _beneficiary, PRICE, _name);
     }

--- a/contracts/mocks/FakeDCLControllerV2.sol
+++ b/contracts/mocks/FakeDCLControllerV2.sol
@@ -24,7 +24,8 @@ contract FakeDCLControllerV2 is DCLControllerV2 {
 
     constructor(
         IERC20Token _acceptedToken,
-        IDCLRegistrar _registrar
-    ) public DCLControllerV2(_acceptedToken, _registrar) {}
+        IDCLRegistrar _registrar,
+        address _feeCollector
+    ) public DCLControllerV2(_acceptedToken, _registrar, _feeCollector) {}
 
 }

--- a/test/SubdomainWithDCLControllerV2.spec.js
+++ b/test/SubdomainWithDCLControllerV2.spec.js
@@ -2023,7 +2023,7 @@ describe('DCL Names V2 with DCLControllerV2', function () {
           { ...fromUser, gasPrice: MAX_GAS_PRICE }
         )
 
-        expect(logs.length).to.be.equal(5)
+        expect(logs.length).to.be.equal(4)
 
         const newOwnerLog = logs[0]
         expect(newOwnerLog.event).to.be.equal('NewOwner')
@@ -2050,12 +2050,7 @@ describe('DCL Names V2 with DCLControllerV2', function () {
         )
         expect(nameRegisteredLog.args._subdomain).to.be.equal(subdomain1)
 
-        const burnLog = logs[3]
-        expect(burnLog.event).to.be.equal('Burn')
-        expect(burnLog.args.burner).to.be.equal(dclControllerContract.address)
-        expect(burnLog.args.value).to.eq.BN(PRICE)
-
-        const nameBoughtLog = logs[4]
+        const nameBoughtLog = logs[3]
         expect(nameBoughtLog.event).to.be.equal('NameBought')
         expect(nameBoughtLog.args._caller).to.be.equal(user)
         expect(nameBoughtLog.args._beneficiary).to.be.equal(user)

--- a/test/SubdomainWithDCLControllerV2.spec.js
+++ b/test/SubdomainWithDCLControllerV2.spec.js
@@ -2055,6 +2055,10 @@ describe('DCL Names V2 with DCLControllerV2', function () {
       })
 
       it('should transfer the fee from the caller to the fee collector', async function () {
+        const price = await dclControllerContract.PRICE()
+
+        expect(price).to.be.gt.BN(0)
+
         const userBalance = await manaContract.balanceOf(user)
         const feeCollectorBalance = await manaContract.balanceOf(feeCollector)
 
@@ -2068,8 +2072,8 @@ describe('DCL Names V2 with DCLControllerV2', function () {
           feeCollector
         )
 
-        expect(newUserBalance).to.eq.BN(userBalance.sub(PRICE))
-        expect(newFeeCollectorBalance).to.eq.BN(feeCollectorBalance.add(PRICE))
+        expect(newUserBalance).to.eq.BN(userBalance.sub(price))
+        expect(newFeeCollectorBalance).to.eq.BN(feeCollectorBalance.add(price))
       })
 
       it('should register a name with a-z', async function () {

--- a/test/SubdomainWithDCLControllerV2.spec.js
+++ b/test/SubdomainWithDCLControllerV2.spec.js
@@ -2054,6 +2054,24 @@ describe('DCL Names V2 with DCLControllerV2', function () {
         expect(currentResolver).to.be.equal(ZERO_ADDRESS)
       })
 
+      it('should transfer the fee from the caller to the fee collector', async function () {
+        const userBalance = await manaContract.balanceOf(user)
+        const feeCollectorBalance = await manaContract.balanceOf(feeCollector)
+
+        await dclControllerContract.register(subdomain1, user, {
+          ...fromUser,
+          gasPrice: MAX_GAS_PRICE,
+        })
+
+        const newUserBalance = await manaContract.balanceOf(user)
+        const newFeeCollectorBalance = await manaContract.balanceOf(
+          feeCollector
+        )
+
+        expect(newUserBalance).to.eq.BN(userBalance.sub(PRICE))
+        expect(newFeeCollectorBalance).to.eq.BN(feeCollectorBalance.add(PRICE))
+      })
+
       it('should register a name with a-z', async function () {
         let name = 'qwertyuiopasdfg'
         await dclControllerContract.register(name, user, fromUser)

--- a/test/SubdomainWithDCLControllerV2.spec.js
+++ b/test/SubdomainWithDCLControllerV2.spec.js
@@ -2059,8 +2059,10 @@ describe('DCL Names V2 with DCLControllerV2', function () {
 
         expect(price).to.be.gt.BN(0)
 
-        let expectedUserBalance = new BN('1000000000000000000000')
-        let expectedFeeCollectorBalance = new BN('1000000000000000000000')
+        const initialBalance = new BN('1000000000000000000000')
+
+        let expectedUserBalance = initialBalance
+        let expectedFeeCollectorBalance = initialBalance
 
         let userBalance = await manaContract.balanceOf(user)
         let feeCollectorBalance = await manaContract.balanceOf(feeCollector)

--- a/test/SubdomainWithDCLControllerV2.spec.js
+++ b/test/SubdomainWithDCLControllerV2.spec.js
@@ -1968,6 +1968,22 @@ describe('DCL Names V2 with DCLControllerV2', function () {
         expect(collector).to.eq.BN(feeCollector)
       })
 
+      it('should emit a FeeCollectorChanged event', async function () {
+        const contract = await DCLControllerV2.new(
+          manaContract.address,
+          dclRegistrarContract.address,
+          feeCollector,
+          creationParams
+        )
+
+        const events = await contract.getPastEvents()
+        const filteredEvents = events.filter(e => e.event === 'FeeCollectorChanged')
+
+        expect(filteredEvents.length).to.be.equal(1)
+        expect(filteredEvents[0].args._oldFeeCollector).to.be.equal(ZERO_ADDRESS)
+        expect(filteredEvents[0].args._newFeeCollector).to.be.equal(feeCollector)
+      })
+
       it('reverts if acceptedToken is not a contract', async function () {
         await assertRevert(
           DCLControllerV2.new(

--- a/test/SubdomainWithDCLControllerV2.spec.js
+++ b/test/SubdomainWithDCLControllerV2.spec.js
@@ -75,6 +75,7 @@ describe('DCL Names V2 with DCLControllerV2', function () {
   let deployer
   let user
   let userController
+  let feeCollector
   let hacker
   let anotherUser
   let fromUserController
@@ -99,6 +100,7 @@ describe('DCL Names V2 with DCLControllerV2', function () {
     anotherUser = accounts[ADDRESS_INDEXES.anotherUser]
     hacker = accounts[ADDRESS_INDEXES.hacker]
     userController = accounts[Object.keys(ADDRESS_INDEXES).length]
+    feeCollector = accounts[Object.keys(ADDRESS_INDEXES).length + 1]
     fromUser = { from: user }
     fromAnotherUser = { from: anotherUser }
     fromUserController = { from: userController }
@@ -176,6 +178,7 @@ describe('DCL Names V2 with DCLControllerV2', function () {
     dclControllerContract = await DCLControllerV2.new(
       manaContract.address,
       dclRegistrarContract.address,
+      feeCollector,
       creationParams
     )
 
@@ -1941,10 +1944,11 @@ describe('DCL Names V2 with DCLControllerV2', function () {
     })
 
     describe('Constructor', function () {
-      it('should be depoyed with valid arguments', async function () {
+      it('should be deployed with valid arguments', async function () {
         const contract = await DCLControllerV2.new(
           manaContract.address,
           dclRegistrarContract.address,
+          feeCollector,
           creationParams
         )
 
@@ -1959,18 +1963,31 @@ describe('DCL Names V2 with DCLControllerV2', function () {
 
         const maxGasPrice = await dclControllerContract.maxGasPrice()
         expect(maxGasPrice).to.eq.BN(MAX_GAS_PRICE)
+
+        const collector = await dclControllerContract.feeCollector()
+        expect(collector).to.eq.BN(feeCollector)
       })
 
       it('reverts if acceptedToken is not a contract', async function () {
         await assertRevert(
-          DCLControllerV2.new(user, dclRegistrarContract.address, creationParams),
+          DCLControllerV2.new(
+            user,
+            dclRegistrarContract.address,
+            feeCollector,
+            creationParams
+          ),
           'Accepted token should be a contract'
         )
       })
 
       it('reverts if registrar is not a contract', async function () {
         await assertRevert(
-          DCLControllerV2.new(manaContract.address, user, creationParams),
+          DCLControllerV2.new(
+            manaContract.address,
+            user,
+            feeCollector,
+            creationParams
+          ),
           'Registrar should be a contract'
         )
       })

--- a/test/SubdomainWithDCLControllerV2.spec.js
+++ b/test/SubdomainWithDCLControllerV2.spec.js
@@ -1977,11 +1977,17 @@ describe('DCL Names V2 with DCLControllerV2', function () {
         )
 
         const events = await contract.getPastEvents()
-        const filteredEvents = events.filter(e => e.event === 'FeeCollectorChanged')
+        const filteredEvents = events.filter(
+          (e) => e.event === 'FeeCollectorChanged'
+        )
 
         expect(filteredEvents.length).to.be.equal(1)
-        expect(filteredEvents[0].args._oldFeeCollector).to.be.equal(ZERO_ADDRESS)
-        expect(filteredEvents[0].args._newFeeCollector).to.be.equal(feeCollector)
+        expect(filteredEvents[0].args._oldFeeCollector).to.be.equal(
+          ZERO_ADDRESS
+        )
+        expect(filteredEvents[0].args._newFeeCollector).to.be.equal(
+          feeCollector
+        )
       })
 
       it('reverts if acceptedToken is not a contract', async function () {
@@ -2385,6 +2391,44 @@ describe('DCL Names V2 with DCLControllerV2', function () {
         await assertRevert(
           dclControllerContract.updateMaxGasPrice(MAX_GAS_PRICE, fromDeployer),
           'Max gas price should be different'
+        )
+      })
+    })
+
+    describe('setFeeCollector', function () {
+      it('should update the fee collector', async function () {
+        const newFeeCollector = anotherUser
+        expect(await dclControllerContract.feeCollector()).to.be.equal(
+          feeCollector
+        )
+        await dclControllerContract.setFeeCollector(
+          newFeeCollector,
+          fromDeployer
+        )
+        expect(await dclControllerContract.feeCollector()).to.be.equal(
+          newFeeCollector
+        )
+      })
+
+      it('should emit a FeeCollectorChanged event', async function () {
+        const oldFeeCollector = feeCollector
+        const newFeeCollector = anotherUser
+
+        const { logs } = await dclControllerContract.setFeeCollector(
+          newFeeCollector,
+          fromDeployer
+        )
+
+        expect(logs.length).to.be.equal(1)
+        expect(logs[0].event).to.be.equal('FeeCollectorChanged')
+        expect(logs[0].args._oldFeeCollector).to.be.equal(oldFeeCollector)
+        expect(logs[0].args._newFeeCollector).to.be.equal(newFeeCollector)
+      })
+
+      it('reverts when the sender is not the owner', async function () {
+        await assertRevert(
+          dclControllerContract.setFeeCollector(anotherUser, fromAnotherUser),
+          'Ownable: caller is not the owner'
         )
       })
     })

--- a/test/SubdomainWithDCLControllerV2.spec.js
+++ b/test/SubdomainWithDCLControllerV2.spec.js
@@ -2059,21 +2059,28 @@ describe('DCL Names V2 with DCLControllerV2', function () {
 
         expect(price).to.be.gt.BN(0)
 
-        const userBalance = await manaContract.balanceOf(user)
-        const feeCollectorBalance = await manaContract.balanceOf(feeCollector)
+        let expectedUserBalance = new BN('1000000000000000000000')
+        let expectedFeeCollectorBalance = new BN('1000000000000000000000')
+
+        let userBalance = await manaContract.balanceOf(user)
+        let feeCollectorBalance = await manaContract.balanceOf(feeCollector)
+
+        expect(userBalance).to.eq.BN(expectedUserBalance)
+        expect(feeCollectorBalance).to.eq.BN(expectedFeeCollectorBalance)
 
         await dclControllerContract.register(subdomain1, user, {
           ...fromUser,
           gasPrice: MAX_GAS_PRICE,
         })
 
-        const newUserBalance = await manaContract.balanceOf(user)
-        const newFeeCollectorBalance = await manaContract.balanceOf(
-          feeCollector
-        )
+        expectedUserBalance = expectedUserBalance.sub(price)
+        expectedFeeCollectorBalance = expectedFeeCollectorBalance.add(price)
 
-        expect(newUserBalance).to.eq.BN(userBalance.sub(price))
-        expect(newFeeCollectorBalance).to.eq.BN(feeCollectorBalance.add(price))
+        userBalance = await manaContract.balanceOf(user)
+        feeCollectorBalance = await manaContract.balanceOf(feeCollector)
+
+        expect(userBalance).to.eq.BN(expectedUserBalance)
+        expect(feeCollectorBalance).to.eq.BN(expectedFeeCollectorBalance)
       })
 
       it('should register a name with a-z', async function () {


### PR DESCRIPTION
Closes #28 

Instead of transferring the fee from the caller to the contract and then burning it, transfer the fee to the fee collector directly.